### PR TITLE
Fixed parameters parsing typos

### DIFF
--- a/files/etc/nginx/sites-enabled/server.conf
+++ b/files/etc/nginx/sites-enabled/server.conf
@@ -131,7 +131,7 @@ server {
         }
 
         if ($myargs ~ "w([_]*)(\d+)") {
-            set $quality $2;
+            set $width $2;
         }
 
         if ($arg_w) {
@@ -144,11 +144,11 @@ server {
         }
 
         if ($myargs ~ "h([_]*)(\d+)") {
-            set $quality $2;
+            set $height $2;
         }
 
         if ($arg_h) {
-            set $width $arg_h;
+            set $height $arg_h;
         }
 
 # quality
@@ -157,7 +157,7 @@ server {
         }
 
         if ($arg_q) {
-            set $width $arg_q;
+            set $quality $arg_q;
         }
 
 # rotate
@@ -166,7 +166,7 @@ server {
         }
 
         if ($arg_r) {
-            set $width $arg_r;
+            set $rotate $arg_r;
         }
 
 # gravity


### PR DESCRIPTION
There was mix-up of parameters parsing between width, height and quality