### PR TITLE
Increases default expires/max-age to 24h

### DIFF
--- a/files/etc/nginx/sites-enabled/server.conf
+++ b/files/etc/nginx/sites-enabled/server.conf
@@ -230,8 +230,8 @@ server {
 
         add_header                  X-ImageProxy-Cache $upstream_cache_status;
         add_header                  X-ImageProxy-Debug $debugkey;
+        expires                     24h;
         add_header                  Cache-Control "public";
-        expires                     12h;
         
         image_filter_sharpen        $sharpen;
         image_filter_jpeg_quality   $quality;
@@ -251,8 +251,8 @@ server {
 
         add_header                  X-ImageProxy-Cache $upstream_cache_status;
         add_header                  X-ImageProxy-Debug $debugkey;
+        expires                     24h;
         add_header                  Cache-Control "public";
-        expires                     12h;
         
         image_filter_sharpen        $sharpen;
         image_filter_jpeg_quality   $quality;


### PR DESCRIPTION
Attempt to close #11. Also, changing default cache duration to 24h (instead of 12h).